### PR TITLE
Update to work with current GitHub

### DIFF
--- a/content.js
+++ b/content.js
@@ -24,9 +24,6 @@ chrome.extension.sendRequest({method: "getLocalStorage", key: "jira"}, function(
         });
     };
 
-    $('#js-repo-pjax-container').on('pjax:end', function() {
-        replaceLinks();
-    });
-
+    $('#js-repo-pjax-container').on('pjax:end', replaceLinks);
     replaceLinks();
 });

--- a/content.js
+++ b/content.js
@@ -1,22 +1,31 @@
 
 chrome.extension.sendRequest({method: "getLocalStorage", key: "jira"}, function(response) {
-	var pattern = /([A-Z]{2,}-\d+)/g;
-	var jira = response.data + '/browse/';
 
-    // selectors in which to look for jira issues
-	var selectors = $('h2.content-title, p.commit-title');
+	const replaceLinks = function() {
+        const pattern = /([A-Z]{2,}-\d+)/g;
+        const jira = response.data + '/browse/';
 
-    selectors.each(function(){
-		var self = $(this);
-		if(self.attr("tagName") == 'A') { return; }
-		
-		var match = pattern.exec(self.text());  
-		if(match[1]) {
-		    // @todo this doesn't work with multiple matches in the same text
-			self.html($(this).text().replace(
-				pattern,
-				' <a style="color:#00775a" target="_blank" href="' + jira + match[1] + '">' + match[1] + '</a>'
-			));
-		}
+        // selectors in which to look for jira issues
+        const selectors = $('h1.gh-header-title, p.commit-title');
+
+        selectors.each(function(){
+            var self = $(this);
+            if(self.attr("tagName") == 'A') { return; }
+
+            var match = pattern.exec(self.text());
+            if(match[1]) {
+                // @todo this doesn't work with multiple matches in the same text
+                self.html($(this).text().replace(
+                    pattern,
+                    ' <a style="" target="_blank" href="' + jira + match[1] + '">' + match[1] + '</a>'
+                ));
+            }
+        });
+	};
+
+    $('#js-repo-pjax-container').on('pjax:end', function() {
+        replaceLinks();
 	});
+
+    replaceLinks();
 });

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 
 chrome.extension.sendRequest({method: "getLocalStorage", key: "jira"}, function(response) {
 
-	const replaceLinks = function() {
+    const replaceLinks = function() {
         const pattern = /([A-Z]{2,}-\d+)/g;
         const jira = response.data + '/browse/';
 
@@ -22,11 +22,11 @@ chrome.extension.sendRequest({method: "getLocalStorage", key: "jira"}, function(
                 ));
             }
         });
-	};
+    };
 
     $('#js-repo-pjax-container').on('pjax:end', function() {
         replaceLinks();
-	});
+    });
 
     replaceLinks();
 });

--- a/content.js
+++ b/content.js
@@ -6,18 +6,19 @@ chrome.extension.sendRequest({method: "getLocalStorage", key: "jira"}, function(
         const jira = response.data + '/browse/';
 
         // selectors in which to look for jira issues
-        const selectors = $('h1.gh-header-title, p.commit-title');
+        const $selectors = $('h1.gh-header-title, p.commit-title');
 
-        selectors.each(function(){
-            var self = $(this);
-            if(self.attr("tagName") == 'A') { return; }
+        $selectors.each(function(){
+            var $self = $(this);
+            if($self.attr("tagName") == 'A') { return; }
 
-            var match = pattern.exec(self.text());
+            var match = pattern.exec($self.text());
             if(match[1]) {
-                // @todo this doesn't work with multiple matches in the same text
-                self.html($(this).text().replace(
+                $self.html($self.text().replace(
                     pattern,
-                    ' <a style="" target="_blank" href="' + jira + match[1] + '">' + match[1] + '</a>'
+                    function (p1) {
+                        return ' <a target="_blank" href="' + jira + p1 + '">' + p1 + '</a>';
+                    }
                 ));
             }
         });


### PR DESCRIPTION
Hi there!

I found your extension to be very cool as it does not really seem there is an "integrated" option to link to JIRA issues from GitHub, so thanks a lot for it!

With this PR I basically:
1. Updated it to work with GitHubs pjax-contentloading so the replacing takes place at the proper point in time
2. Fixed the 5 yo issue that multiple different links in the same text would all get replaced to the first match

Keep up your good work! :thumbsup: